### PR TITLE
Fixed grammar

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,6 +3,6 @@
 </p>
 <h1 align="center">Delusionzz</h1>
 <h2 >What we do</h2>
-- Make api's
+- Make apis
 - Educational sites
 - Utility bookmarklets


### PR DESCRIPTION
Replaced `api's` with `apis` it looks wrong but it isn't.